### PR TITLE
pass bearer token to protected endpoints

### DIFF
--- a/src/services/auth0.js
+++ b/src/services/auth0.js
@@ -14,6 +14,7 @@ const _useAuth0 = () => {
         domain: import.meta.env.VITE_AUTH0_DOMAIN,
         client_id: import.meta.env.VITE_AUTH0_CLIENT_ID,
         redirect_uri: import.meta.env.VITE_AUTH0_CALLBACK_URL,
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
       })
     );
 

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -1,5 +1,8 @@
 import { writable } from "svelte/store";
 import { callExternalApi } from "./external-api.service";
+import { useAuth0 } from "./auth0";
+
+let { getAccessToken } = useAuth0;
 
 const apiServerUrl = import.meta.env.VITE_API_SERVER_URL;
 
@@ -26,11 +29,13 @@ export const getPublicResource = async () => {
 };
 
 export const getProtectedResource = async () => {
+  const accessToken = await getAccessToken();
   const config = {
     url: `${apiServerUrl}/api/messages/protected`,
     method: "GET",
     headers: {
       "content-type": "application/json",
+      "Authorization": `Bearer ${accessToken}`
     },
   };
 
@@ -46,11 +51,13 @@ export const getProtectedResource = async () => {
 };
 
 export const getAdminResource = async () => {
+  const accessToken = await getAccessToken();
   const config = {
     url: `${apiServerUrl}/api/messages/admin`,
     method: "GET",
     headers: {
       "content-type": "application/json",
+      "Authorization": `Bearer ${accessToken}`
     },
   };
 


### PR DESCRIPTION
Updates the demo to work with the backends examples. This has been tested with https://github.com/auth0-developer-hub/api_flask_python_hello-world/tree/basic-role-based-access-control

My `.env` file contained the following after this work. I believe `VITE_AUTH0_AUDIENCE` will need added to https://developer.auth0.com/resources/code-samples/spa/svelte/basic-authentication
```
VITE_AUTH0_DOMAIN=
VITE_AUTH0_AUDIENCE=
VITE_AUTH0_CLIENT_ID=
VITE_AUTH0_CALLBACK_URL=
VITE_API_SERVER_URL=
```